### PR TITLE
Update Dockerfile to make run scripts executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ENV \
 
 COPY ./ /app/epg
 COPY root/ /
+#make init scripts runnable
+RUN chmod +x /etc/services.d/docker-iptv-or-epg/run /etc/cont-init.d/50-config
 
 RUN mkdir -p /app/epg && \
   echo "**** install build dependencies ****" && \


### PR DESCRIPTION
Added line to Dockerfile to make the following files executable, as NPM could not run with permission denied errors and would not load npm:

/etc/services.d/docker-iptv-or-epg/run
/etc/cont-init.d/50-config